### PR TITLE
fix: add ArrayBuffer type for save presentation by Buffer

### DIFF
--- a/src/core-interfaces.ts
+++ b/src/core-interfaces.ts
@@ -1876,7 +1876,7 @@ export interface IPresentationProps extends PresentationProps {
 
 export interface AddFontProps {
 	typeface: string
-	fontBlob: Blob
+	fontBlob: Blob | ArrayBuffer
 }
 
 export interface FontInfo extends AddFontProps {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -2685,7 +2685,7 @@ declare namespace PptxGenJS {
 
 export interface AddFontProps {
 	typeface: string
-	fontBlob: Blob
+	fontBlob: Blob | ArrayBuffer
 }
 
 export interface FontInfo extends AddFontProps {


### PR DESCRIPTION
# Submission Guidelines

- Only modify the `src/*.ts` files (do not submit `dist` or `src/bld` files)
- New and updated properties must be added to `src/core-interfaces.ts` and `types/index.d.ts`
- New and updated features must be included in the corresponding `demos/modules/*.mjs` file
- Review previously accepted changes for examples on what to provide

## Change Summary
add ArrayBuffer type for save presentation by Buffer

## Change Type
- [ ] Bug fix

## Motivation and Context
When I add font from .fntdata presentation can't be saved, and Buffer return error from node_modules/jszip/lib/utils.js "Can't read the data of 'ppt/fonts/font1.fntdata'. Is it in a supported JavaScript type (String, Blob, ArrayBuffer, etc) ?"

## Checklist before requesting a review
- [ ] My code follows the style guidelines of this project
- [ ] My changes generate no new eslint warnings
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have included code/tests that prove my fix is effective or that my feature works
- [ ] I have used the "Run All Demos" feature on the [browser demo](/demos/browser/index.html) and no errors were found


Thanks for your contribution!
